### PR TITLE
typo in configure output

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,7 +1,7 @@
 dnl $Id$
 dnl config.m4 for extension xxtea
 PHP_ARG_ENABLE(xxtea, xxtea support,
-[  --enabled-xxtea       Enable xxtea support], [enabled_xxtea="yes"])
+[  --enable-xxtea          Enable xxtea support], [enabled_xxtea="yes"])
 
 dnl Check whether the extension is enabled at all
 if test "$PHP_XXTEA" != "no"; then


### PR DESCRIPTION
Minor typo fix.

I encounter a strange issue with the tarball on pecl forge, all the files have 777 rights 

```
 $ tar tvf xxtea-1.0.5.tgz 
 -rw-r--r-- andot/staff    2362 2015-03-23 07:27 package.xml
 -rwxrwxrwx andot/staff     518 2015-03-23 07:27 xxtea-1.0.5/tests/xxtea.phpt
 -rwxrwxrwx andot/staff      52 2015-03-23 07:27 xxtea-1.0.5/CREDITS
 -rwxrwxrwx andot/staff    1104 2015-03-23 07:27 xxtea-1.0.5/LICENSE.md
 -rwxrwxrwx andot/staff    1885 2015-03-23 07:27 xxtea-1.0.5/README.md
 -rwxrwxrwx andot/staff    1842 2015-03-23 07:27 xxtea-1.0.5/README_zh_CN.md
 -rwxrwxrwx andot/staff     424 2015-03-23 07:27 xxtea-1.0.5/config.m4
 -rwxrwxrwx andot/staff     111 2015-03-23 07:27 xxtea-1.0.5/config.w32
 -rwxrwxrwx andot/staff    1587 2015-03-23 07:27 xxtea-1.0.5/php_xxtea.h
 -rwxrwxrwx andot/staff   11006 2015-03-23 07:27 xxtea-1.0.5/php_xxtea.c
```

While everything is correct in the git repo, and in a new tarball generated by "pecl package".

Can you please ensure correct perm on next release (really, this is not a big issue)
