### PR TITLE
rename XXTEA_VERSION macro

### DIFF
--- a/php_xxtea.c
+++ b/php_xxtea.c
@@ -266,7 +266,7 @@ zend_module_entry xxtea_module_entry = {
     NULL,
     NULL,
     ZEND_MINFO(xxtea),
-    XXTEA_VERSION,
+    PHP_XXTEA_VERSION,
     STANDARD_MODULE_PROPERTIES
 };
 
@@ -360,7 +360,7 @@ ZEND_MSHUTDOWN_FUNCTION(xxtea) {
 ZEND_MINFO_FUNCTION(xxtea) {
     php_info_print_table_start();
     php_info_print_table_row(2, "xxtea support", "enabled");
-    php_info_print_table_row(2, "xxtea version", XXTEA_VERSION);
+    php_info_print_table_row(2, "xxtea version", PHP_XXTEA_VERSION);
     php_info_print_table_row(2, "xxtea author", XXTEA_AUTHOR);
     php_info_print_table_row(2, "xxtea homepage", XXTEA_HOMEPAGE);
     php_info_print_table_end();
@@ -368,7 +368,7 @@ ZEND_MINFO_FUNCTION(xxtea) {
 
 ZEND_FUNCTION(xxtea_info) {
     array_init(return_value);
-    __add_assoc_string(return_value, "ext_version", XXTEA_VERSION);
+    __add_assoc_string(return_value, "ext_version", PHP_XXTEA_VERSION);
     __add_assoc_string(return_value, "ext_build_date", XXTEA_BUILD_DATE);
     __add_assoc_string(return_value, "ext_author", XXTEA_AUTHOR);
 }

--- a/php_xxtea.h
+++ b/php_xxtea.h
@@ -25,7 +25,7 @@ extern zend_module_entry xxtea_module_entry;
 
 #define XXTEA_MODULE_NAME        "xxtea"
 #define XXTEA_BUILD_DATE         __DATE__ " " __TIME__
-#define XXTEA_VERSION            "1.0.5"
+#define PHP_XXTEA_VERSION        "1.0.6"
 #define XXTEA_AUTHOR             "Ma Bingyao"
 #define XXTEA_HOMEPAGE           "https://github.com/xxtea/xxtea-pecl"
 


### PR DESCRIPTION
Using PHP_foo_VERSION standard macro name will allow check of this value on upload.

See http://git.php.net/?p=web/pecl.git;a=blob;f=public_html/release-upload.php#l108
