### PR TITLE
feat: 添加对 PHP 8+ 的支持并更新 CI 配置

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ php:
   - 5.6
   - 7.0.0
   - 7.0.1
+  - 8.0
+  - 8.1
+  - 8.2
+  - 8.3
+  - 8.4
   - nightly
 
 notifications:
@@ -19,7 +24,7 @@ env:
 
 #Compile
 before_script:
-    - /bin/sh ./travis/compile.sh
+  - /bin/sh ./travis/compile.sh
 
 # Run PHPs run-tests.php
 script: make test

--- a/package.xml
+++ b/package.xml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <package
- packagerversion="1.4.11"
- version="2.0"
- xmlns="http://pear.php.net/dtd/package-2.0"
- xmlns:tasks="http://pear.php.net/dtd/tasks-1.0"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0
+    packagerversion="1.4.11"
+    version="2.0"
+    xmlns="http://pear.php.net/dtd/package-2.0"
+    xmlns:tasks="http://pear.php.net/dtd/tasks-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0
 http://pear.php.net/dtd/tasks-1.0.xsd
 http://pear.php.net/dtd/package-2.0
-http://pear.php.net/dtd/package-2.0.xsd">
+http://pear.php.net/dtd/package-2.0.xsd"
+>
     <name>xxtea</name>
     <channel>pecl.php.net</channel>
     <summary>XXTEA encryption algorithm extension for PHP.</summary>
@@ -25,8 +26,8 @@ It is different from the original XXTEA encryption algorithm. It encrypts and de
     <date>2015-04-05</date>
     <time>11:14:37</time>
     <version>
-        <release>1.0.11</release>
-        <api>1.0.11</api>
+        <release>1.0.12</release>
+        <api>1.0.12</api>
     </version>
     <stability>
         <release>stable</release>
@@ -61,9 +62,26 @@ It is different from the original XXTEA encryption algorithm. It encrypts and de
     </dependencies>
     <providesextension>xxtea</providesextension>
     <extsrcrelease>
-        <configureoption default="yes" name="enable-xxtea" prompt="whether to enable xxtea support" />
+        <configureoption
+            default="yes"
+            name="enable-xxtea"
+            prompt="whether to enable xxtea support"
+        />
     </extsrcrelease>
     <changelog>
+        <release>
+            <version>
+                <release>1.0.12</release>
+                <api>1.0.12</api>
+            </version>
+            <stability>
+                <release>stable</release>
+                <api>stable</api>
+            </stability>
+            <date>2025-05-29</date>
+            <license uri="http://mit-license.org/">MIT</license>
+            <notes>Support php8+</notes>
+        </release>
         <release>
             <version>
                 <release>1.0.11</release>

--- a/php_xxtea.c
+++ b/php_xxtea.c
@@ -80,6 +80,10 @@
 typedef int length_t;
 #define __RETURN_STRINGL(s, l) RETURN_STRINGL(s, l, 0)
 #define __add_assoc_string(arg, key, str) add_assoc_string(arg, key, str, 1)
+#elif PHP_MAJOR_VERSION < 8
+typedef size_t length_t;
+#define __RETURN_STRINGL(s, l) RETVAL_STRINGL(s, l); efree(s); return;
+#define __add_assoc_string(arg, key, str) add_assoc_string(arg, key, str)
 #else
 typedef size_t length_t;
 #define __RETURN_STRINGL(s, l) RETVAL_STRINGL(s, l); efree(s); return;
@@ -228,17 +232,17 @@ static uint8_t * xxtea_ubyte_decrypt(const uint8_t * data, size_t len, const uin
     return out;
 }
 
-ZEND_BEGIN_ARG_INFO_EX(xxtea_encrypt_arginfo, 0, 0, 2)
-    ZEND_ARG_INFO(0, data)
-    ZEND_ARG_INFO(0, key)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(xxtea_encrypt_arginfo, 0, 2, IS_STRING, 1)
+    ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(xxtea_decrypt_arginfo, 0, 0, 2)
-    ZEND_ARG_INFO(0, data)
-    ZEND_ARG_INFO(0, key)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(xxtea_decrypt_arginfo, 0, 2, IS_STRING, 1)
+    ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(xxtea_info_arginfo, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(xxtea_info_arginfo, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 #ifndef ZEND_FE_END
@@ -281,11 +285,7 @@ ZEND_FUNCTION(xxtea_encrypt) {
     size_t i, ret_length;
     uint8_t fixed_key[16];
 
-#ifdef TSRMLS_CC
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &data, &data_len, &key, &key_len) == FAILURE) {
-#else
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &data, &data_len, &key, &key_len) == FAILURE) {
-#endif
         return;
     }
     if (data_len == 0) {
@@ -318,11 +318,7 @@ ZEND_FUNCTION(xxtea_decrypt) {
     size_t i, ret_length;
     uint8_t fixed_key[16];
 
-#ifdef TSRMLS_CC
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &data, &data_len, &key, &key_len) == FAILURE) {
-#else
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &data, &data_len, &key, &key_len) == FAILURE) {
-#endif
         return;
     }
     if (data_len == 0) {
@@ -354,11 +350,7 @@ static zend_function_entry xxtea_method[] = {
 ZEND_MINIT_FUNCTION(xxtea) {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "XXTEA", xxtea_method);
-#ifdef TSRMLS_CC
-    xxtea_ce = zend_register_internal_class(&ce TSRMLS_CC);
-#else
     xxtea_ce = zend_register_internal_class(&ce);
-#endif
     return SUCCESS;
 }
 


### PR DESCRIPTION
- 在 .travis.yml 中添加 PHP 8.0 至 8.4 的测试环境
- 更新 package.xml 版本号至 1.0.12 并添加 PHP 8+ 支持说明
- 修改 php_xxtea.c 以兼容 PHP 8+ 的 API 变化